### PR TITLE
Fixes syntax error in Pressure Weapons ammo.json

### DIFF
--- a/Pressure Weapons/ammo/ammo.json
+++ b/Pressure Weapons/ammo/ammo.json
@@ -41,7 +41,7 @@
         "dispersion": 0,
         "recoil": 20,
         "count" : 3,
-        "loudness": "0",
+        "loudness": 0,
         "effects" : [ "RECOVER_35", "BOLT" ]
     },
     {
@@ -64,7 +64,7 @@
         "dispersion": 0,
         "recoil": 20,
         "count" : 3,
-        "loudness": "0",
+        "loudness": 0,
         "effects": [ "RECOVER_35", "BOLT" ]
     }
 ]


### PR DESCRIPTION
Quotation marks caused an error on loading CDDA.