### PR TITLE
Update recipe in More Armor mod

### DIFF
--- a/More_Armor/recipes.json
+++ b/More_Armor/recipes.json
@@ -933,7 +933,7 @@
     "components": [
       [ [ "rag", 36 ] ],
       [ [ "ragpouch", 3 ], [ "leather_pouch", 3 ] ],
-      [ [ "chestpouch", 5 ], [ "legpouch_large", 3 ], [ "magbandolier", 2 ] ],
+      [ [ "chestpouch", 5 ], [ "legpouch_large", 3 ], [ "chestrig", 2 ] ],
       [ [ "plastic_chunk", 4 ] ]
     ]
   },


### PR DESCRIPTION
magbandolier was obsoleted, replaced with chestrig