### PR TITLE
Remove mon_exploder from monster group in Machine mod

### DIFF
--- a/Machine/overmap_specials.json
+++ b/Machine/overmap_specials.json
@@ -41,7 +41,6 @@
       { "monster" : "mon_turret_rifle", "freq" : 30, "cost_multiplier" : 20 },
       { "monster" : "mon_turret_bmg", "freq" : 10, "cost_multiplier" : 30 },
       { "monster" : "mon_turret_searchlight", "freq" : 50, "cost_multiplier" : 1 },
-      { "monster" : "mon_exploder", "freq" : 50, "cost_multiplier" : 5 },
       { "monster" : "mon_tripod", "freq" : 30, "cost_multiplier" : 10 },
       { "monster" : "mon_chickenbot", "freq" : 10, "cost_multiplier" : 20 },
       { "monster" : "mon_tankbot", "freq" : 5, "cost_multiplier" : 30 }


### PR DESCRIPTION
mon_exploder was a turret which was removed from the game in Jan 2018, since it hadn't been called to spawn anywhere in years. Since it is no longer defined, having it in the monster group throws an error.
Alternative fix- redefine mon_exploder based on the original turret and update it. If anyone wants to do that feel free.